### PR TITLE
Improve RSR and WSR output

### DIFF
--- a/decode_spi.rb
+++ b/decode_spi.rb
@@ -84,10 +84,10 @@ lines.each do |l|
                         puts "%f : CHIP_ERASE" % time
                 end
             when SPI_STATE::READ_STATUS
-                puts "%f : RSR : %x" % [time, miso]
+                puts "%f : RSR : 0x%02x" % [time, miso]
                 state = SPI_STATE::CMD_WAIT
             when SPI_STATE::WRITE_STATUS
-                puts "%f : WSR : %x" % [time, mosi]
+                puts "%f : WSR : 0x%02x" % [time, mosi]
                 state = SPI_STATE::CMD_WAIT
             when SPI_STATE::READ_ID
                 if data.length < 3 then

--- a/decode_spi.rb
+++ b/decode_spi.rb
@@ -84,7 +84,7 @@ lines.each do |l|
                         puts "%f : CHIP_ERASE" % time
                 end
             when SPI_STATE::READ_STATUS
-                puts "%f : RSR : %x" % [time, mosi]
+                puts "%f : RSR : %x" % [time, miso]
                 state = SPI_STATE::CMD_WAIT
             when SPI_STATE::WRITE_STATUS
                 puts "%f : WSR : %x" % [time, mosi]


### PR DESCRIPTION
This pull request improves two things. Firstly, we now show MISO, instead of MOSI next to the RSR "read status" command. MOSI is always 0xFF there, but MISO is the actual contents of the status register.

Secondly, prepend "0x" to the status bytes next to RSR and WSR and always show them as two hexadecimal digits. This makes it clear whether 10 is a decimal ten or hexadecimal sixteen, for example.